### PR TITLE
Add comprehensive backend unit tests

### DIFF
--- a/test/backend/data_structures/ds_account_test.dart
+++ b/test/backend/data_structures/ds_account_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_account.dart';
+
+void main() {
+  test('constructor sets default values and generates id', () {
+    final account = DsAccount(name: 'Alice', color: Colors.blue, score: 5);
+    expect(account.id, isNotEmpty);
+    expect(account.name, 'Alice');
+    expect(account.color, Colors.blue);
+    expect(account.score, 5);
+  });
+
+  test('update mutates fields and marks instance as dirty', () {
+    final account = DsAccount(name: 'Bob', color: Colors.green, score: 1, fromDB: true);
+    account.update(newName: 'Robert', newColor: Colors.red, newScore: 10);
+
+    expect(account.name, 'Robert');
+    expect(account.color, Colors.red);
+    expect(account.score, 10);
+    expect(account.fromDB, isFalse);
+  });
+
+  test('updateComplete copies values from another account with same id', () {
+    final original = DsAccount(name: 'Carol', color: Colors.purple, score: 2);
+    final updated = DsAccount(
+      id: original.id,
+      name: 'Caroline',
+      color: Colors.orange,
+      score: 8,
+      fromDB: true,
+    );
+
+    original.updateComplete(updated);
+    expect(original.name, 'Caroline');
+    expect(original.color, Colors.orange);
+    expect(original.score, 8);
+    expect(original.fromDB, isFalse);
+  });
+
+  test('copyWith keeps original id but allows overriding fields', () {
+    final account = DsAccount(name: 'Dave', color: Colors.black, score: 4);
+    final copy = account.copyWith(newName: 'David', newColor: Colors.white, newScore: 7);
+
+    expect(copy.id, account.id);
+    expect(copy.name, 'David');
+    expect(copy.color, Colors.white);
+    expect(copy.score, 7);
+    expect(account.name, 'Dave');
+    expect(account.color, Colors.black);
+    expect(account.score, 4);
+  });
+}

--- a/test/backend/data_structures/ds_repeating_templates_dates_test.dart
+++ b/test/backend/data_structures/ds_repeating_templates_dates_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_repeating_templates_dates.dart';
+import 'package:scrubbit/Backend/Functions/f_time.dart';
+
+void main() {
+  test('getDate returns correct yearly date with overflow adjustment', () {
+    final dates = DsRepeatingTemplatesDates(month: 2, monthDay: 30);
+    final today = getNowWithoutTime();
+    final expectedDay = adjustDayForMonth(30, 2, today.year + 1);
+    expect(dates.getDate(1), DateTime(today.year + 1, 2, expectedDay));
+  });
+
+  test('getDate returns monthly date within same month', () {
+    final dates = DsRepeatingTemplatesDates(monthDay: 31);
+    final today = getNowWithoutTime();
+    final base = DateTime(today.year, today.month, 1);
+    final expectedDay = adjustDayForMonth(31, base.month, base.year);
+    expect(dates.getDate(0), DateTime(base.year, base.month, expectedDay));
+  });
+
+  test('getDate calculates weekly occurrences relative to today', () {
+    final targetWeekday = DateTime.friday;
+    final dates = DsRepeatingTemplatesDates(weekDay: targetWeekday);
+    final today = getNowWithoutTime();
+    final delta = (targetWeekday - today.weekday + DateTime.daysPerWeek) %
+        DateTime.daysPerWeek;
+    final anchor = today.add(Duration(days: delta));
+
+    expect(dates.getDate(0), anchor);
+    expect(dates.getDate(2), anchor.add(const Duration(days: 14)));
+  });
+
+  test('getDate returns null when no configuration provided', () {
+    final dates = DsRepeatingTemplatesDates();
+    expect(dates.getDate(0), isNull);
+  });
+}

--- a/test/backend/data_structures/ds_repeating_templates_test.dart
+++ b/test/backend/data_structures/ds_repeating_templates_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_repeating_templates.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_repeating_templates_dates.dart';
+import 'package:scrubbit/Backend/Functions/f_time.dart';
+
+void main() {
+  DsRepeatingTemplates buildTemplate() {
+    return DsRepeatingTemplates(
+      repeatingType: 0,
+      repeatingIntervall: 1,
+      repeatingCount: null,
+      repeatAfterDone: false,
+      startDate: DateTime(2024, 1, 1),
+      endDate: null,
+      lastDoneDate: null,
+      repeatingDates: [],
+    );
+  }
+
+  test('update modifies every field and resets fromDB', () {
+    final template = buildTemplate();
+    template.update(
+      newRepeatingType: 1,
+      newRepeatingIntervall: 2,
+      newRepeatingCount: 5,
+      newRepeatAfterDone: true,
+      newStartDate: DateTime(2024, 2, 1),
+      newEndDate: DateTime(2024, 3, 1),
+      newLastDoneDate: DateTime(2024, 2, 2),
+      newRepeatingDates: [DsRepeatingTemplatesDates(weekDay: DateTime.monday)],
+    );
+
+    expect(template.repeatingType, 1);
+    expect(template.repeatingIntervall, 2);
+    expect(template.repeatingCount, 5);
+    expect(template.repeatAfterDone, isTrue);
+    expect(template.startDate, DateTime(2024, 2, 1));
+    expect(template.endDate, DateTime(2024, 3, 1));
+    expect(template.lastDoneDate, DateTime(2024, 2, 2));
+    expect(template.repeatingDates.length, 1);
+    expect(template.fromDB, isFalse);
+  });
+
+  test('copyWith clones template while keeping id', () {
+    final template = buildTemplate();
+    final copy = template.copyWith(
+      newRepeatingType: 3,
+      newRepeatingIntervall: 4,
+      newRepeatingCount: 6,
+      newRepeatAfterDone: true,
+      newStartDate: DateTime(2025, 1, 1),
+      newEndDate: DateTime(2025, 2, 1),
+      newLastDoneDate: DateTime(2025, 1, 15),
+    );
+
+    expect(copy.id, template.id);
+    expect(copy.repeatingType, 3);
+    expect(copy.repeatingIntervall, 4);
+    expect(copy.repeatingCount, 6);
+    expect(copy.repeatAfterDone, isTrue);
+    expect(copy.startDate, DateTime(2025, 1, 1));
+    expect(copy.endDate, DateTime(2025, 2, 1));
+    expect(copy.lastDoneDate, DateTime(2025, 1, 15));
+    expect(template.repeatingType, 0);
+  });
+
+  test('updateComplete copies everything from another template', () {
+    final original = buildTemplate();
+    final replacement = DsRepeatingTemplates(
+      id: original.id,
+      repeatingType: 2,
+      repeatingIntervall: 5,
+      repeatingCount: 8,
+      repeatAfterDone: true,
+      startDate: DateTime(2024, 4, 1),
+      endDate: DateTime(2024, 5, 1),
+      lastDoneDate: DateTime(2024, 4, 10),
+      repeatingDates: [DsRepeatingTemplatesDates(monthDay: 15)],
+    );
+
+    original.updateComplete(replacement);
+
+    expect(original.repeatingType, 2);
+    expect(original.repeatingIntervall, 5);
+    expect(original.repeatingCount, 8);
+    expect(original.repeatAfterDone, isTrue);
+    expect(original.startDate, DateTime(2024, 4, 1));
+    expect(original.endDate, DateTime(2024, 5, 1));
+    expect(original.lastDoneDate, DateTime(2024, 4, 10));
+    expect(original.repeatingDates.length, 1);
+    expect(original.fromDB, isFalse);
+  });
+
+  test('getDates daily returns start date when not completed yet', () {
+    final startDate = getNowWithoutTime().subtract(const Duration(days: 3));
+    final template = DsRepeatingTemplates(
+      repeatingType: 0,
+      repeatingIntervall: 1,
+      repeatAfterDone: false,
+      startDate: startDate,
+      lastDoneDate: null,
+      repeatingDates: [],
+    );
+
+    final dates = template.getDates();
+    expect(dates, [startDate]);
+  });
+
+  test('getDates daily with repeatAfterDone true schedules after completion', () {
+    final today = getNowWithoutTime();
+    final template = DsRepeatingTemplates(
+      repeatingType: 0,
+      repeatingIntervall: 2,
+      repeatAfterDone: true,
+      startDate: today.subtract(const Duration(days: 5)),
+      lastDoneDate: today.subtract(const Duration(days: 1)),
+      repeatingDates: [],
+    );
+
+    final dates = template.getDates();
+    expect(dates.single, template.lastDoneDate!.add(const Duration(days: 2)));
+  });
+
+  test('getDates daily without repeatAfterDone lists missed and next dates', () {
+    final today = getNowWithoutTime();
+    final template = DsRepeatingTemplates(
+      repeatingType: 0,
+      repeatingIntervall: 2,
+      repeatAfterDone: false,
+      startDate: today.subtract(const Duration(days: 5)),
+      lastDoneDate: today.subtract(const Duration(days: 4)),
+      repeatingDates: [],
+    );
+
+    final dates = template.getDates();
+    expect(dates.length, 2);
+    expect(dates[0], today.add(const Duration(days: 1)));
+    expect(dates[1], today.add(const Duration(days: 3)));
+  });
+
+  test('getDates returns start date when no repeating dates configured', () {
+    final template = DsRepeatingTemplates(
+      repeatingType: 1,
+      repeatingIntervall: 1,
+      repeatAfterDone: false,
+      startDate: DateTime(2024, 1, 1),
+      repeatingDates: [],
+    );
+
+    expect(template.getDates(), [DateTime(2024, 1, 1)]);
+  });
+
+  test('getDates weekly returns upcoming configured days', () {
+    final today = getNowWithoutTime();
+    final datesConfig = [
+      DsRepeatingTemplatesDates(weekDay: today.weekday),
+      DsRepeatingTemplatesDates(weekDay: (today.weekday % 7) + 1),
+    ];
+    final template = DsRepeatingTemplates(
+      repeatingType: 1,
+      repeatingIntervall: 1,
+      repeatAfterDone: false,
+      startDate: today.subtract(const Duration(days: 14)),
+      repeatingDates: datesConfig,
+    );
+
+    final dates = template.getDates();
+    final daysSinceStart = today.difference(template.startDate).inDays;
+    final daysToNext = (daysSinceStart ~/ 7) % template.repeatingIntervall;
+
+    final expected = datesConfig
+        .map((config) => config.getDate(daysToNext))
+        .whereType<DateTime>()
+        .toList();
+
+    expect(dates, expected);
+  });
+}

--- a/test/backend/data_structures/ds_task_date_test.dart
+++ b/test/backend/data_structures/ds_task_date_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_account.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_task.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_task_date.dart';
+
+void main() {
+  DsTask buildTask({int offset = 0}) {
+    return DsTask(
+      name: 'Task',
+      emoji: '😀',
+      onEveryDate: false,
+      offset: offset,
+      isImportant: true,
+      timeFrom: const TimeOfDay(hour: 9, minute: 0),
+      timeUntil: const TimeOfDay(hour: 10, minute: 0),
+      taskDates: [],
+    );
+  }
+
+  test('plannedDate applies task offset', () {
+    final task = buildTask(offset: 2);
+    final date = DsTaskDate(
+      plannedDate: DateTime(2024, 1, 1),
+      task: task,
+    );
+
+    expect(date.plannedDate, DateTime(2024, 1, 3));
+  });
+
+  test('update changes stored values and marks instance dirty', () {
+    final task = buildTask();
+    final taskDate = DsTaskDate(
+      plannedDate: DateTime(2024, 1, 1),
+      task: task,
+      fromDB: true,
+    );
+    final account = DsAccount(name: 'Tester', color: Colors.blue);
+    final newDate = DateTime(2024, 1, 5);
+
+    taskDate.update(
+      newPlannedDate: newDate,
+      newDoneDate: newDate,
+      newDoneBy: [account],
+    );
+
+    expect(taskDate.plannedDate, newDate);
+    expect(taskDate.doneDate, newDate);
+    expect(taskDate.doneBy, [account]);
+    expect(taskDate.fromDB, isFalse);
+  });
+
+  test('updateComplete copies everything from matching task date', () {
+    final task = buildTask();
+    final otherTask = buildTask(offset: 1);
+    final original = DsTaskDate(
+      plannedDate: DateTime(2024, 1, 1),
+      task: task,
+    );
+    final replacement = DsTaskDate(
+      id: original.id,
+      plannedDate: DateTime(2024, 2, 1),
+      doneDate: DateTime(2024, 2, 3),
+      doneBy: [DsAccount(name: 'A', color: Colors.red)],
+      task: otherTask,
+      fromDB: true,
+    );
+
+    original.updateComplete(replacement);
+
+    expect(original.plannedDate, replacement.plannedDate);
+    expect(original.doneDate, replacement.doneDate);
+    expect(original.task, otherTask);
+    expect(original.fromDB, isFalse);
+  });
+
+  test('copyWith creates detached copy sharing the id', () {
+    final task = buildTask();
+    final account = DsAccount(name: 'Copy', color: Colors.green);
+    final original = DsTaskDate(
+      plannedDate: DateTime(2024, 3, 1),
+      task: task,
+      doneBy: [account],
+    );
+
+    final copy = original.copyWith(
+      newPlannedDate: DateTime(2024, 3, 2),
+      newDoneDate: DateTime(2024, 3, 3),
+      newDoneBy: [],
+      newTask: task,
+    );
+
+    expect(copy.id, original.id);
+    expect(copy.plannedDate, DateTime(2024, 3, 2));
+    expect(copy.doneDate, DateTime(2024, 3, 3));
+    expect(copy.doneBy, isEmpty);
+    expect(original.plannedDate, DateTime(2024, 3, 1));
+    expect(original.doneBy, [account]);
+  });
+
+  test('markDone adds account and sets done date to today', () {
+    final task = buildTask();
+    final account = DsAccount(name: 'Worker', color: Colors.orange);
+    final date = DsTaskDate(
+      plannedDate: DateTime(2024, 4, 1),
+      task: task,
+    );
+
+    date.markDone(account);
+
+    expect(date.doneBy, contains(account));
+    expect(date.doneDate, isNotNull);
+    expect(date.isDoneToday(), isTrue);
+  });
+}

--- a/test/backend/data_structures/ds_task_test.dart
+++ b/test/backend/data_structures/ds_task_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_account.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_repeating_templates.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_repeating_templates_dates.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_task.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_task_date.dart';
+import 'package:scrubbit/Backend/Functions/f_time.dart';
+
+void main() {
+  DsTask buildTask({
+    int offset = 0,
+    DsRepeatingTemplates? template,
+  }) {
+    return DsTask(
+      name: 'Task',
+      emoji: '😀',
+      onEveryDate: false,
+      offset: offset,
+      isImportant: true,
+      timeFrom: const TimeOfDay(hour: 9, minute: 0),
+      timeUntil: const TimeOfDay(hour: 10, minute: 0),
+      repeatingTemplate: template,
+      taskDates: [],
+    );
+  }
+
+  DsTaskDate buildDate(DsTask task, DateTime date) {
+    return DsTaskDate(
+      plannedDate: date,
+      task: task,
+    );
+  }
+
+  test('addTaskDate tracks newly added items', () {
+    final task = buildTask();
+    final date = buildDate(task, DateTime(2024, 1, 1));
+
+    task.addTaskDate(date);
+
+    expect(task.taskDates, contains(date));
+    expect(task.addTaskDates, contains(date));
+  });
+
+  test('removeTaskDate differentiates between fresh and persisted entries', () {
+    final task = buildTask();
+    final persisted = buildDate(task, DateTime(2024, 2, 1));
+    task.setTaskDates = [persisted];
+
+    final fresh = buildDate(task, DateTime(2024, 3, 1));
+    task.addTaskDate(fresh);
+    task.removeTaskDate(fresh);
+
+    expect(task.addTaskDates, isEmpty);
+    expect(task.removedTaskDates, isEmpty);
+
+    task.removeTaskDate(persisted);
+    expect(task.removedTaskDates, [persisted]);
+    expect(task.taskDates, isEmpty);
+  });
+
+  test('clearTaskDate removes everything but keeps history', () {
+    final task = buildTask();
+    final date1 = buildDate(task, DateTime(2024, 4, 3));
+    final date2 = buildDate(task, DateTime(2024, 4, 1));
+    task.setTaskDates = [date1, date2];
+
+    task.clearTaskDate();
+
+    expect(task.taskDates, isEmpty);
+    expect(task.removedTaskDates, containsAll([date1, date2]));
+    expect(task.addTaskDates, isEmpty);
+  });
+
+  test('resetTaskDate restores previous entries sorted by date', () {
+    final task = buildTask();
+    final date1 = buildDate(task, DateTime(2024, 5, 4));
+    final date2 = buildDate(task, DateTime(2024, 5, 2));
+    task.setTaskDates = [date1, date2];
+    task.clearTaskDate();
+
+    task.resetTaskDate();
+
+    expect(task.removedTaskDates, isEmpty);
+    expect(task.taskDates, [date2, date1]);
+  });
+
+  test('savedToDb clears tracking lists', () {
+    final task = buildTask();
+    final date = buildDate(task, DateTime(2024, 6, 1));
+    task.addTaskDate(date);
+    task.removeTaskDate(date);
+
+    task.savedToDb();
+
+    expect(task.addTaskDates, isEmpty);
+    expect(task.removedTaskDates, isEmpty);
+  });
+
+  test('update changes fields and synchronises task dates', () {
+    final task = buildTask(offset: 1);
+    final date1 = buildDate(task, DateTime(2024, 7, 1));
+    final date2 = buildDate(task, DateTime(2024, 7, 2));
+    task.setTaskDates = [date1, date2];
+
+    final newOwner = DsAccount(name: 'Owner', color: Colors.red);
+    final replacement = buildDate(task, DateTime(2024, 7, 3));
+
+    task.update(
+      newName: 'Updated Task',
+      newEmoji: '🎉',
+      newOnEveryDate: true,
+      newOffset: 2,
+      newIsImportant: false,
+      newTimeFrom: const TimeOfDay(hour: 8, minute: 0),
+      newTimeUntil: const TimeOfDay(hour: 9, minute: 0),
+      newTaskOwners: [newOwner],
+      newTaskDates: [date2, replacement],
+    );
+
+    expect(task.name, 'Updated Task');
+    expect(task.emoji, '🎉');
+    expect(task.onEveryDate, isTrue);
+    expect(task.offset, 2);
+    expect(task.isImportant, isFalse);
+    expect(task.timeFrom, const TimeOfDay(hour: 8, minute: 0));
+    expect(task.timeUntil, const TimeOfDay(hour: 9, minute: 0));
+    expect(task.taskOwners, [newOwner]);
+    expect(task.taskDates.map((d) => d.plannedDate),
+        containsAll([date2.plannedDate, replacement.plannedDate]));
+    expect(task.addTaskDates.length, 1);
+    expect(task.addTaskDates.first.plannedDate, replacement.plannedDate);
+    expect(task.removedTaskDates.length, 1);
+    expect(task.removedTaskDates.first.plannedDate, date1.plannedDate);
+    expect(task.fromDB, isFalse);
+  });
+
+  test('copyWith creates deep copy of fields', () {
+    final owner = DsAccount(name: 'Owner', color: Colors.blue);
+    final template = DsRepeatingTemplates(
+      repeatingType: 1,
+      repeatingIntervall: 1,
+      repeatAfterDone: true,
+      startDate: DateTime(2024, 1, 1),
+      repeatingDates: [DsRepeatingTemplatesDates(weekDay: DateTime.monday)],
+    );
+    final task = buildTask(template: template);
+    final date = buildDate(task, DateTime(2024, 1, 1));
+    task.setTaskDates = [date];
+    task.update(newTaskOwners: [owner]);
+
+    final copy = task.copyWith(newName: 'Clone');
+
+    expect(copy.id, task.id);
+    expect(copy.name, 'Clone');
+    expect(copy.repeatingTemplate, isNot(same(template)));
+    expect(copy.repeatingTemplate!.repeatingType, template.repeatingType);
+    expect(copy.taskOwners, isNot(same(task.taskOwners)));
+    expect(copy.taskDates, isNot(same(task.taskDates)));
+    expect(copy.taskDates.first.task, isNot(task));
+    expect(task.name, isNot('Clone'));
+  });
+
+  test('updateComplete copies all values when ids match', () {
+    final template = DsRepeatingTemplates(
+      repeatingType: 0,
+      repeatingIntervall: 1,
+      repeatAfterDone: false,
+      startDate: DateTime(2024, 1, 1),
+    );
+    final task = buildTask(template: template);
+    final replacement = DsTask(
+      id: task.id,
+      name: 'Replacement',
+      emoji: '🙂',
+      onEveryDate: true,
+      offset: 3,
+      isImportant: false,
+      timeFrom: const TimeOfDay(hour: 6, minute: 0),
+      timeUntil: const TimeOfDay(hour: 7, minute: 0),
+      repeatingTemplate: template.copyWith(newRepeatAfterDone: true),
+      taskOwners: [DsAccount(name: 'Owner', color: Colors.green)],
+      taskDates: [],
+    );
+    replacement.setTaskDates = [buildDate(replacement, DateTime(2024, 2, 1))];
+
+    task.updateComplete(replacement);
+
+    expect(task.name, 'Replacement');
+    expect(task.onEveryDate, isTrue);
+    expect(task.offset, 3);
+    expect(task.repeatingTemplate!.repeatAfterDone, isTrue);
+    expect(task.taskOwners!.first.name, 'Owner');
+    expect(task.taskDates.length, 1);
+    expect(task.fromDB, isFalse);
+  });
+
+  test('createRepeatingDates expands repeating template dates', () {
+    final template = DsRepeatingTemplates(
+      repeatingType: 0,
+      repeatingIntervall: 1,
+      repeatAfterDone: false,
+      startDate: getNowWithoutTime(),
+    );
+    final task = buildTask(template: template);
+
+    task.createRepeatingDates();
+
+    expect(task.taskDates, isNotEmpty);
+    expect(task.taskDates.first.task, task);
+  });
+}

--- a/test/backend/functions/f_input_formatter_test.dart
+++ b/test/backend/functions/f_input_formatter_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrubbit/Backend/Functions/f_input_formatter.dart';
+
+void main() {
+  group('NoLeadingZeroFormatter', () {
+    final formatter = NoLeadingZeroFormatter();
+
+    test('allows empty field', () {
+      expect(
+        formatter.formatEditUpdate(
+          TextEditingValue.empty,
+          const TextEditingValue(text: ''),
+        ),
+        const TextEditingValue(text: ''),
+      );
+    });
+
+    test('rejects input that starts with zero', () {
+      final oldValue = const TextEditingValue(text: '1');
+      final newValue = const TextEditingValue(text: '01');
+      expect(formatter.formatEditUpdate(oldValue, newValue), oldValue);
+    });
+
+    test('accepts non-zero input', () {
+      final oldValue = const TextEditingValue(text: '1');
+      final newValue = const TextEditingValue(text: '12');
+      expect(formatter.formatEditUpdate(oldValue, newValue), newValue);
+    });
+  });
+}

--- a/test/backend/functions/f_lists_test.dart
+++ b/test/backend/functions/f_lists_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrubbit/Backend/Functions/f_lists.dart';
+
+void main() {
+  group('rotate', () {
+    test('rotates list forward from given index', () {
+      expect(rotate([1, 2, 3, 4], 2), [3, 4, 1, 2]);
+    });
+
+    test('supports negative start positions by wrapping', () {
+      expect(rotate([1, 2, 3, 4], -1), [4, 1, 2, 3]);
+    });
+  });
+
+  group('timeSpann', () {
+    test('returns contiguous segment when from <= to', () {
+      expect(timeSpann([0, 1, 2, 3, 4], 1, 3), [1, 2, 3]);
+    });
+
+    test('wraps around when from is greater than to', () {
+      expect(timeSpann([0, 1, 2, 3, 4], 3, 1), [3, 4, 0, 1]);
+    });
+  });
+
+  group('dateTimeSpann', () {
+    test('produces inclusive range when from is before to', () {
+      final from = DateTime(2024, 1, 1);
+      final to = DateTime(2024, 1, 3);
+      expect(dateTimeSpann(from, to), [from, from.add(const Duration(days: 1)), to]);
+    });
+
+    test('swaps order when from is after to', () {
+      final from = DateTime(2024, 1, 5);
+      final to = DateTime(2024, 1, 2);
+      final result = dateTimeSpann(from, to);
+      expect(result.first, to);
+      expect(result.last, from);
+      expect(result.length, 4);
+    });
+  });
+}

--- a/test/backend/functions/f_time_test.dart
+++ b/test/backend/functions/f_time_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrubbit/Backend/Functions/f_time.dart';
+
+void main() {
+  group('format helpers', () {
+    test('formatDateTime pads hour and minute with leading zeros', () {
+      final dateTime = DateTime(2024, 1, 2, 5, 7);
+      expect(formatDateTime(dateTime), '05:07');
+    });
+
+    test('formatDate handles optional month and year parts', () {
+      final date = DateTime(2024, 3, 15);
+      expect(formatDate(date, true, true), 'März 2024');
+      expect(formatDate(date, false, true), ' 2024');
+      expect(formatDate(date, false, false), '');
+    });
+
+    test('formatDateDay builds dd.mm.yyyy strings', () {
+      final date = DateTime(2024, 11, 9);
+      expect(formatDateDay(date, true, true), '09.11.2024');
+      expect(formatDateDay(date, false, false), '09');
+    });
+
+    test('formatTime renders TimeOfDay values', () {
+      const time = TimeOfDay(hour: 4, minute: 9);
+      expect(formatTime(time), '04:09');
+    });
+  });
+
+  group('time conversions', () {
+    test('timeOfDayToInt converts to minute count and back', () {
+      const time = TimeOfDay(hour: 13, minute: 37);
+      final totalMinutes = timeOfDayToInt(time);
+      expect(totalMinutes, 13 * 60 + 37);
+      expect(timeOfDayToInt(null), isNull);
+
+      final restored = intToTimeOfDay(totalMinutes);
+      expect(restored!.hour, 13);
+      expect(restored.minute, 37);
+      expect(intToTimeOfDay(null), isNull);
+    });
+  });
+
+  group('date list builders', () {
+    test('getNext7Weekdays returns consecutive dates starting today', () {
+      final now = DateTime.now();
+      final expectedStart = DateTime(now.year, now.month, now.day);
+      final result = getNext7Weekdays();
+
+      expect(result.length, 7);
+      for (var i = 0; i < result.length; i++) {
+        final expected = expectedStart.add(Duration(days: i));
+        expect(result[i], expected);
+      }
+    });
+
+    test('groupByMonth separates dates per month preserving order', () {
+      final dates = [
+        DateTime(2024, 1, 1),
+        DateTime(2024, 1, 15),
+        DateTime(2024, 2, 1),
+        DateTime(2024, 2, 10),
+      ];
+
+      final grouped = groupByMonth(dates);
+      expect(grouped.length, 2);
+      expect(grouped[0], [dates[0], dates[1]]);
+      expect(grouped[1], [dates[2], dates[3]]);
+    });
+
+    test('datesUntilEndOfWeek contains every day until Sunday', () {
+      final today = getNowWithoutTime();
+      final dates = datesUntilEndOfWeek();
+
+      expect(dates.first, today);
+      for (var i = 0; i < dates.length; i++) {
+        expect(dates[i], today.add(Duration(days: i)));
+      }
+      expect(dates.last.weekday, DateTime.sunday);
+    });
+
+    test('datesUntilEndOfMonth spans to the final day of month', () {
+      final today = getNowWithoutTime();
+      final dates = datesUntilEndOfMonth();
+      final startOfNextMonth = today.month == 12
+          ? DateTime(today.year + 1, 1, 1)
+          : DateTime(today.year, today.month + 1, 1);
+      final expectedLast = startOfNextMonth.subtract(const Duration(days: 1));
+
+      expect(dates.first, today);
+      expect(dates.last, expectedLast);
+      expect(dates.length, expectedLast.difference(today).inDays + 1);
+    });
+  });
+
+  group('relative day checks', () {
+    test('isSameDay compares only calendar day components', () {
+      final base = DateTime(2024, 6, 3, 10, 30);
+      final other = DateTime(2024, 6, 3, 23, 59);
+      expect(isSameDay(base, other), isTrue);
+      expect(isSameDay(base, base.add(const Duration(days: 1))), isFalse);
+    });
+
+    test('isToday and isTomorrow follow current system date', () {
+      expect(isToday(DateTime.now()), isTrue);
+      expect(isTomorrow(DateTime.now().add(const Duration(days: 1))), isTrue);
+      expect(isTomorrow(DateTime.now()), isFalse);
+    });
+
+    test('isInCurrentWeek returns true only for current week range', () {
+      final today = getNowWithoutTime();
+      final startOfWeek = today.subtract(Duration(days: today.weekday - 1));
+      final inside = startOfWeek.add(const Duration(days: 2));
+      final outside = startOfWeek.subtract(const Duration(days: 1));
+
+      expect(isInCurrentWeek(inside), isTrue);
+      expect(isInCurrentWeek(outside), isFalse);
+    });
+
+    test('isInCurrentMonth checks month and year against today', () {
+      final today = getNowWithoutTime();
+      final nextMonth = DateTime(today.year, today.month + 1, today.day);
+      expect(isInCurrentMonth(today), isTrue);
+      expect(isInCurrentMonth(nextMonth), isFalse);
+    });
+
+    test('allDaysUntilSundayIncluded validates provided list', () {
+      final complete = datesUntilEndOfWeek();
+      expect(allDaysUntilSundayIncluded(complete), isTrue);
+      expect(allDaysUntilSundayIncluded(complete.sublist(0, complete.length - 1)),
+          isFalse);
+      expect(allDaysUntilSundayIncluded([]), isFalse);
+    });
+
+    test('allDaysUntilEndOfMonthIncluded validates full span', () {
+      final allDays = datesUntilEndOfMonth();
+      expect(allDaysUntilEndOfMonthIncluded(allDays), isTrue);
+      expect(
+        allDaysUntilEndOfMonthIncluded(allDays.sublist(0, allDays.length - 1)),
+        isFalse,
+      );
+      expect(allDaysUntilEndOfMonthIncluded([]), isFalse);
+    });
+  });
+
+  group('utility calculations', () {
+    test('getNowWithoutTime applies offsets to current date', () {
+      final now = DateTime.now();
+      final expected = DateTime(now.year + 1, now.month + 1, now.day + 2);
+      final result = getNowWithoutTime(addYear: 1, addMonth: 1, addDay: 2);
+      expect(result, expected);
+    });
+
+    test('daysUntilEndOfWeek counts days based on weekday', () {
+      final monday = DateTime(2024, 3, 4); // Monday
+      expect(daysUntilEndOfWeek(monday), DateTime.daysPerWeek - monday.weekday);
+    });
+
+    test('daysUntilEndOfMonth uses month length for calculation', () {
+      final date = DateTime(2024, 2, 20);
+      expect(daysUntilEndOfMonth(date), 9);
+    });
+
+    test('addToDate supports multiple repeat types', () {
+      final base = DateTime(2024, 1, 10);
+      expect(addToDate(base, 0, 3), base.add(const Duration(days: 3)));
+      expect(addToDate(base, 1, 2), base.add(const Duration(days: 14)));
+      expect(addToDate(base, 2, 1), DateTime(2024, 2, 10));
+      expect(addToDate(base, 3, 1), DateTime(2025, 1, 10));
+
+      final fallback = addToDate(null, 99, 5);
+      expect(fallback, getNowWithoutTime());
+    });
+
+    test('adjustDayForMonth clamps overflowing days to month length', () {
+      expect(adjustDayForMonth(31, 4, 2024), 30);
+      expect(adjustDayForMonth(29, 2, 2023), 28);
+      expect(adjustDayForMonth(15, 6, 2024), 15);
+    });
+
+    test('monthDifference and yearDifference compute spans correctly', () {
+      final from = DateTime(2023, 5, 1);
+      final to = DateTime(2024, 8, 1);
+      expect(monthDifference(from, to), 15);
+      expect(yearDifference(from, to), 1);
+    });
+  });
+}

--- a/test/backend/utils/test_data_test.dart
+++ b/test/backend/utils/test_data_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scrubbit/Backend/DB/DataStrukture/ds_account.dart';
+import 'package:scrubbit/test_data.dart';
+
+void main() {
+  test('createAccounts generates requested number of accounts', () {
+    final accounts = createAccounts(3);
+    expect(accounts.length, 3);
+    expect(accounts, everyElement(isA<DsAccount>()));
+    expect(accounts.map((a) => a.id).toSet().length, accounts.length);
+  });
+
+  test('createAccount returns a single account instance', () {
+    final account = createAccount();
+    expect(account, isA<DsAccount>());
+    expect(account.name, 'name');
+  });
+
+  test('createTasks currently returns empty list placeholder', () {
+    expect(createTasks(5), isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests for time, list, and formatter helper functions
- cover data structure behaviors for accounts, tasks, task dates, and repeating templates
- exercise sample data builders to ensure generated objects behave as expected

## Testing
- flutter test *(fails: flutter command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d11cdf08f08326b344d780d0f6698a