### PR TITLE
Adjust scroll handling in score overview

### DIFF
--- a/lib/Fronend/Components/Elements/e_task_box_title.dart
+++ b/lib/Fronend/Components/Elements/e_task_box_title.dart
@@ -47,10 +47,9 @@ class ETaskBoxTitle extends StatelessWidget {
               child:
                   withScroll
                       ? SingleChildScrollView(
-                        physics:
-                            withScrollPhysiks
-                                ? AlwaysScrollableScrollPhysics()
-                                : NeverScrollableScrollPhysics(),
+                        physics: withScrollPhysiks
+                            ? const AlwaysScrollableScrollPhysics()
+                            : null,
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: children,

--- a/lib/Fronend/Components/Elements/e_task_box_title.dart
+++ b/lib/Fronend/Components/Elements/e_task_box_title.dart
@@ -47,9 +47,10 @@ class ETaskBoxTitle extends StatelessWidget {
               child:
                   withScroll
                       ? SingleChildScrollView(
-                        physics: withScrollPhysiks
-                            ? const AlwaysScrollableScrollPhysics()
-                            : null,
+                        physics:
+                            withScrollPhysiks
+                                ? AlwaysScrollableScrollPhysics()
+                                : NeverScrollableScrollPhysics(),
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: children,

--- a/lib/Fronend/Components/Widgets/e_score_overview.dart
+++ b/lib/Fronend/Components/Widgets/e_score_overview.dart
@@ -40,7 +40,7 @@ class _EScoreOverviewState extends State<EScoreOverview> {
     return ETaskBoxTitle(
       flex: 2,
       title: textScoreOverview,
-      withScroll: true,
+      withScroll: false,
       withScrollPhysiks: false,
       behindTitle: Expanded(
         child: ESelectAccount(
@@ -55,43 +55,54 @@ class _EScoreOverviewState extends State<EScoreOverview> {
         ),
       ),
       children: [
-        EScoreOverviewDiagramm(
-          accounts:
-              selectedAccounts.isEmpty ? account.accounts : selectedAccounts,
-        ),
-        SizedBox(height: 20),
-        Row(
-          spacing: 260,
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(6),
-              child: Row(
-                spacing: 5,
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              EScoreOverviewDiagramm(
+                accounts: selectedAccounts.isEmpty
+                    ? account.accounts
+                    : selectedAccounts,
+              ),
+              SizedBox(height: 20),
+              Row(
+                spacing: 260,
                 children: [
-                  Icon(Icons.history_rounded, color: buttonColor, size: 32),
-                  Text(textTaskHistory, style: taskHistory),
+                  Padding(
+                    padding: const EdgeInsets.all(6),
+                    child: Row(
+                      spacing: 5,
+                      children: [
+                        Icon(Icons.history_rounded,
+                            color: buttonColor, size: 32),
+                        Text(textTaskHistory, style: taskHistory),
+                      ],
+                    ),
+                  ),
+                  CIconButton(
+                    onPressed: () {},
+                    icon: Transform(
+                      alignment: Alignment.center,
+                      transform: Matrix4.identity()..scale(-1.0, 1.0, 1.0),
+                      child: const Icon(
+                        Icons.sort_rounded,
+                        size: 32,
+                        color: buttonColor,
+                      ),
+                    ),
+                  ),
                 ],
               ),
-            ),
-            CIconButton(
-              onPressed: () {},
-              icon: Transform(
-                alignment: Alignment.center,
-                transform: Matrix4.identity()..scale(-1.0, 1.0, 1.0),
-                child: const Icon(
-                  Icons.sort_rounded,
-                  size: 32,
-                  color: buttonColor,
+              SizedBox(height: 10),
+              Expanded(
+                child: ETaskDoneHistory(
+                  accounts: selectedAccounts.isEmpty
+                      ? account.accounts
+                      : selectedAccounts,
                 ),
               ),
-            ),
-          ],
-        ),
-        SizedBox(height: 10),
-        ETaskDoneHistory(
-          accounts: selectedAccounts.isEmpty
-              ? account.accounts
-              : selectedAccounts,
+            ],
+          ),
         ),
       ],
     );

--- a/lib/Fronend/Components/Widgets/e_score_overview.dart
+++ b/lib/Fronend/Components/Widgets/e_score_overview.dart
@@ -40,7 +40,7 @@ class _EScoreOverviewState extends State<EScoreOverview> {
     return ETaskBoxTitle(
       flex: 2,
       title: textScoreOverview,
-      withScroll: false,
+      withScroll: true,
       withScrollPhysiks: false,
       behindTitle: Expanded(
         child: ESelectAccount(
@@ -60,9 +60,10 @@ class _EScoreOverviewState extends State<EScoreOverview> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               EScoreOverviewDiagramm(
-                accounts: selectedAccounts.isEmpty
-                    ? account.accounts
-                    : selectedAccounts,
+                accounts:
+                    selectedAccounts.isEmpty
+                        ? account.accounts
+                        : selectedAccounts,
               ),
               SizedBox(height: 20),
               Row(
@@ -73,8 +74,11 @@ class _EScoreOverviewState extends State<EScoreOverview> {
                     child: Row(
                       spacing: 5,
                       children: [
-                        Icon(Icons.history_rounded,
-                            color: buttonColor, size: 32),
+                        Icon(
+                          Icons.history_rounded,
+                          color: buttonColor,
+                          size: 32,
+                        ),
                         Text(textTaskHistory, style: taskHistory),
                       ],
                     ),
@@ -96,9 +100,10 @@ class _EScoreOverviewState extends State<EScoreOverview> {
               SizedBox(height: 10),
               Expanded(
                 child: ETaskDoneHistory(
-                  accounts: selectedAccounts.isEmpty
-                      ? account.accounts
-                      : selectedAccounts,
+                  accounts:
+                      selectedAccounts.isEmpty
+                          ? account.accounts
+                          : selectedAccounts,
                 ),
               ),
             ],

--- a/lib/Fronend/Components/Widgets/e_score_overview.dart
+++ b/lib/Fronend/Components/Widgets/e_score_overview.dart
@@ -41,7 +41,7 @@ class _EScoreOverviewState extends State<EScoreOverview> {
       flex: 2,
       title: textScoreOverview,
       withScroll: true,
-      withScrollPhysiks: true,
+      withScrollPhysiks: false,
       behindTitle: Expanded(
         child: ESelectAccount(
           reverse: true,
@@ -88,7 +88,11 @@ class _EScoreOverviewState extends State<EScoreOverview> {
           ],
         ),
         SizedBox(height: 10),
-        ETaskDoneHistory(accounts: selectedAccounts),
+        ETaskDoneHistory(
+          accounts: selectedAccounts.isEmpty
+              ? account.accounts
+              : selectedAccounts,
+        ),
       ],
     );
   }

--- a/lib/Fronend/Components/Widgets/e_task_done_history.dart
+++ b/lib/Fronend/Components/Widgets/e_task_done_history.dart
@@ -15,30 +15,32 @@ class ETaskDoneHistory extends StatelessWidget {
     final home = context.read<UiHome>();
     return SizedBox(
       width: 500,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children:
-            home
-                .doneTask(accounts)
-                .map(
-                  (taskDate) => Padding(
-                    padding: const EdgeInsets.all(10),
-                    child: InkWell(
-                      onTap: () {
-                        showDialog(
-                          context: context,
-                          builder:
-                              (context) => TaskDonePopup(taskDate: taskDate),
-                        );
-                      },
-                      child: ETaskElement(
-                        task: taskDate.task,
-                        taskDate: taskDate,
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children:
+              home
+                  .doneTask(accounts)
+                  .map(
+                    (taskDate) => Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: InkWell(
+                        onTap: () {
+                          showDialog(
+                            context: context,
+                            builder:
+                                (context) => TaskDonePopup(taskDate: taskDate),
+                          );
+                        },
+                        child: ETaskElement(
+                          task: taskDate.task,
+                          taskDate: taskDate,
+                        ),
                       ),
                     ),
-                  ),
-                )
-                .toList(),
+                  )
+                  .toList(),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- disable the custom scroll physics in `EScoreOverview` while keeping the scrollable layout
- ensure the task history uses the selected accounts when available
- wrap `ETaskDoneHistory` content in a `SingleChildScrollView` so the history list can scroll

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df9453e1608326a4f07f44437a4990